### PR TITLE
Wayland "support"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -237,17 +237,16 @@ function _DisplayOff() {
     } else {
         _DisplayOffXWindows();
     }
-		
-}
-
-function _DisplayOffXWindows() {
-	//use xset to disable the screen
-	Util.spawn(['xset','dpms','force','off']);  
 	 
 	// disable external mice if set in the preferences
 	if(Prefs._getHandleMouse() ) {
 		disable_mouse();
 	}
+}
+
+function _DisplayOffXWindows() {
+	//use xset to disable the screen
+	Util.spawn(['xset','dpms','force','off']);  
 }
 
 function _DisplayOffWayland() {

--- a/extension.js
+++ b/extension.js
@@ -232,7 +232,11 @@ function _DisplayOff() {
 
 	//close the menu
 	systemMenu.menu.itemActivated();
-    _DisplayOffXWindows();
+    if (GLib.getenv('XDG_SESSION_TYPE') == 'wayland') {
+        _DisplayOffWayland();
+    } else {
+        _DisplayOffXWindows();
+    }
 		
 }
 

--- a/extension.js
+++ b/extension.js
@@ -232,6 +232,11 @@ function _DisplayOff() {
 
 	//close the menu
 	systemMenu.menu.itemActivated();
+    _DisplayOffXWindows();
+		
+}
+
+function _DisplayOffXWindows() {
 	//use xset to disable the screen
 	Util.spawn(['xset','dpms','force','off']);  
 	 
@@ -239,7 +244,6 @@ function _DisplayOff() {
 	if(Prefs._getHandleMouse() ) {
 		disable_mouse();
 	}
-		
 }
 
 

--- a/extension.js
+++ b/extension.js
@@ -232,11 +232,11 @@ function _DisplayOff() {
 
 	//close the menu
 	systemMenu.menu.itemActivated();
-    if (GLib.getenv('XDG_SESSION_TYPE') == 'wayland') {
-        _DisplayOffWayland();
-    } else {
-        _DisplayOffXWindows();
-    }
+	if (GLib.getenv('XDG_SESSION_TYPE') == 'wayland') {
+		_DisplayOffWayland();
+	} else {
+		_DisplayOffXWindows();
+	}
 	 
 	// disable external mice if set in the preferences
 	if(Prefs._getHandleMouse() ) {
@@ -251,8 +251,8 @@ function _DisplayOffXWindows() {
 
 function _DisplayOffWayland() {
 	Util.spawn(['dbus-send', '--session', '--dest=org.gnome.ScreenSaver',
-                '--type=method_call', '/org/gnome/ScreenSaver',
-                'org.gnome.ScreenSaver.SetActive', 'boolean:true']);  
+	            '--type=method_call', '/org/gnome/ScreenSaver',
+	            'org.gnome.ScreenSaver.SetActive', 'boolean:true']);  
 }
 
 

--- a/extension.js
+++ b/extension.js
@@ -246,6 +246,12 @@ function _DisplayOffXWindows() {
 	}
 }
 
+function _DisplayOffWayland() {
+	Util.spawn(['dbus-send', '--session', '--dest=org.gnome.ScreenSaver',
+                '--type=method_call', '/org/gnome/ScreenSaver',
+                'org.gnome.ScreenSaver.SetActive', 'boolean:true']);  
+}
+
 
 
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 { 
-  "description": "Adds a button to the status menu to turn off the screen.\n\n(requires 'xset' and 'xinput' (xorg) . This extension is not compatible with wayland.)", 
+  "description": "Adds a button to the status menu to turn off the screen.\n\n(requires 'xset' and 'xinput' (xorg). On wayland it instead activates the screen saver. So make sure it is configured appropriately.)",
   "name": "Turn off Display", 
   "settings-schema": "org.gnome.shell.extensions.turnoffdisplay", 
   "shell-version": [


### PR DESCRIPTION
Thank you for this nice and simple extension. After switching to wayland I really missed it. So here is a quick fix which activates the screen saver under wayland (without locking it).

--Adam