### PR TITLE
Ported to SpiderMonkey 60

### DIFF
--- a/css_adjust.js
+++ b/css_adjust.js
@@ -84,7 +84,7 @@ function checkAggregatemenuwidth() {
 	let allButtonWidth = actionChildren[1].get_width()*2;
 	
 	//calculate new width
-	for each (let button in actionChildren){
+	for (let button of actionChildren) {
 		allButtonWidth += button.get_width();
 	}
 

--- a/xinput_mouse.js
+++ b/xinput_mouse.js
@@ -93,7 +93,7 @@ function get_mouse_ids() {
 
 function switch_devices(mode, deviceIDs) {
 	// enable/disable devices by ID
-	for each (var device in deviceIDs) {
+	for (let device of deviceIDs) {
 		if(mode == "on") {
 			execute_sync('xinput --enable ' + device);
 		}


### PR DESCRIPTION
Removed Mozilla-specific JavaScript extension 'for each' which is
expected to be removed from SpiderMonkey 60 (as it has been removed from
the pre-release)

Thanks: https://extensions.gnome.org/extension/1455/spidermonkey-60-migration-validator/